### PR TITLE
Support newer dash buttons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ before_install:
 - gem update --system
 - gem --version
 rvm:
-- 2.0.0
 - 2.1.10
-- 2.2.5
-- 2.3.1
+- 2.2.7
+- 2.3.4
+- 2.4.1
 - ruby-head
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ The `lifx_dash` command will now be available in your PATH.
 
 ### Dash Button Setup
 
-Follow Amazon's Dash button setup steps, but **stop** before choosing any
-particular product to purchase. If necessary, you can [factory
+Follow Amazon's Dash button setup steps, but **stop** before choosing a product
+to purchase. Pressing the button should pulse white while connecting to wi-fi,
+then flash orange. If necessary, you can [factory
 reset](https://www.amazon.com/gp/help/customer/display.html?nodeId=201746400)
 your button and start the setup from scratch.
 
@@ -58,20 +59,11 @@ Next use the `snoop` command to determine the button's MAC address:
 
     $ sudo lifx_dash snoop -i en0
 
-This will listen on network interface 'en0' for ARP packets from any Dash
-button. Take a note of the MAC address that's logged when you press. To list
-network interfaces on your machine use:
+This will listen on network interface 'en0' for Dash button packets. Take a note
+of the MAC address that's logged when you press. To list network interfaces on
+your machine use:
 
-    $ ifconfig
-    # or
     $ ifconfig -l
-
-#### Snooping Tips
-
-Wait for the network to quiet down, before pressing the button, since other
-devices may respond with ARP packets of their own when you press. Take care to
-choose the MAC address from the ARP packet that occurs only once from a single
-MAC address.
 
 ### LIFX Bulb Setup
 
@@ -160,12 +152,12 @@ take a moment and check it hasn't already been raised (and possibly closed).
 
 This gem uses the [PacketFu](https://rubygems.org/gems/packetfu) gem (and
 [libpcap](https://sourceforge.net/projects/libpcap/) under the hood) to monitor
-data packets on your network. This packet stream is filtered by
-[ARP](https://en.wikipedia.org/wiki/Address_Resolution_Protocol) packets (sent
-when a device attempts to identify itself). Amazon Dash buttons do this on every
-press.
+data packets on your network. This packet stream filters
+[ARP](https://en.wikipedia.org/wiki/Address_Resolution_Protocol) packets and
+DHCP packets (sent from 0.0.0.0). Older buttons use the ARP method, while newer
+buttons issue DHCP packets.
 
-When an ARP packet is detected with a known source MAC address, the LIFX HTTP
+When a valid packet is detected with a known source MAC address, the LIFX HTTP
 API [toggle-power](https://api.developer.lifx.com/docs/toggle-power) endpoint is
 requested, with a selector and authorization header.
 

--- a/bin/lifx_dash
+++ b/bin/lifx_dash
@@ -35,11 +35,8 @@ end
 
 
 desc "Listen for Dash button presses on the network and show packet information"
-long_desc "Monitor the sepcified network interface for any Dash button ARP
-packets and log the device MAC address to stdout. Wait for the network to quiet
-down, before pressing the button, since other devices may respond with ARP
-packets of their own when you press. Take care to choose the MAC address from
-the ARP packet that occurs only once from a single MAC address."
+long_desc "Monitor the sepcified network interface for valid Dash button packets
+and log the device MAC address to stdout."
 command :snoop do |c|
   c.desc "Network Interface"
   c.default_value CONFIG["iface"] || "en0"
@@ -52,7 +49,7 @@ end
 
 desc "Listen for a Dash button press, and the toggle selected lights"
 long_desc "Monitor the sepcified network interface, filtered by a Dash button
-MAC address. If a valid ARP packet is detected, the LIFX lights (identified by
+MAC address. If a valid packet is detected, the LIFX lights (identified by
 the selector) will be toggled using the LIFX HTTP API (v1). You can optionally
 pass a LIFX bulb selector (the bulb ID), or choose to daemonize the `monitor`
 process.

--- a/lib/lifx_dash/capturer.rb
+++ b/lib/lifx_dash/capturer.rb
@@ -3,6 +3,16 @@ require "packetfu"
 module LifxDash
   class Capturer
 
+    # Berkeley Packet filter for Amazon Dash buttons
+    #
+    #  - older dash buttons issue an ARP packet from 0.0.0.0
+    #  - newer buttons broadcast a DHCP request from 0.0.0.0
+    #  - use the following bfp in WireShark to snoop for raw packets
+    #    - (arp or (udp.srcport == 68 and udp.dstport == 67)) and ip.src == 0.0.0.0
+    #  - for more details see https://github.com/ide/dash-button/issues/36
+    #
+    PACKET_FILTER = "(arp or (udp and src port 68 and dst port 67)) and src host 0.0.0.0"
+
     attr_reader :iface
 
     def initialize(network_iface_id)
@@ -12,25 +22,22 @@ module LifxDash
     def listen(&block)
       # examine packets on the stream
       capturer.stream.each do |packet|
-        pkt = PacketFu::ARPPacket.parse(packet)
-        # parse packet header
-        mac = PacketFu::EthHeader.str2mac(pkt.eth_src)
-        # valid ARP pkt when opcode is 1
-        if pkt.arp_opcode == 1
+        pkt = PacketFu::IPPacket.parse(packet)
+        # only consider the first packet sent
+        if pkt.ip_id == 1
+          mac = PacketFu::EthHeader.str2mac(pkt.eth_src)
           block.call(pkt, mac) if block
         end
       end
     end
 
-
     private
-
     def capturer
-      # filter and capture ARP packets on network interface
+      # capture (and filter) packets on network interface
       @capturer ||= PacketFu::Capture.new(
         iface: @iface,
         start: true,
-        filter: "arp"
+        filter: PACKET_FILTER
       )
     end
   end

--- a/lib/lifx_dash/snoop.rb
+++ b/lib/lifx_dash/snoop.rb
@@ -9,8 +9,6 @@ module LifxDash
 
     def run
       puts "Snooping for dash button packets on #{iface} ... press [CTRL-c] to stop\n\n"
-      puts " * wait for the network to quiet down, before pressing the button"
-      puts " * you might get more than 1 ARP packet when pressing, use the MAC address that occurs once\n\n"
 
       LifxDash::Capturer.new(iface).listen do |pkt, mac|
         LOGGER.info "possible Dash button press from MAC address: #{mac} -- pkt summary: #{pkt.peek}"

--- a/man/lifx_dash.1
+++ b/man/lifx_dash.1
@@ -1,7 +1,7 @@
 .\" generated with Ronn/v0.7.3
 .\" http://github.com/rtomayko/ronn/tree/0.7.3
 .
-.TH "LIFX_DASH" "1" "June 2016" "" ""
+.TH "LIFX_DASH" "1" "June 2017" "" ""
 .
 .SH "NAME"
 \fBlifx_dash\fR \- Toggle LIFX lights with an Amazon Dash button
@@ -31,18 +31,18 @@ A \fBconfig\fR command also exists, allowing you to set default options for \fBm
 \fBlifx_dash\fR requires at least one LIFX bulb, and any Amazon Dash button\. You will also need a wifi network and root access to sniff packets on your network adaptor\.
 .
 .P
-Follow Amazon\'s Dash button setup steps, but \fBstop\fR before choosing any particular product to purchase\. You aill also need a free LIFX API token from here: \fIhttps://cloud\.lifx\.com/settings\fR
+Follow Amazon\'s Dash button setup steps, but \fBstop\fR before choosing a product to purchase\. Pressing the button should pulse white while connecting to wi\-fi, then flash orange\. If necessary, you can factory reset \fIhttps://www\.amazon\.com/gp/help/customer/display\.html?nodeId=201746400\fR your button and start the setup from scratch\.
+.
+.P
+You will also need a free LIFX API token from here: \fIhttps://cloud\.lifx\.com/settings\fR
 .
 .SH "OPTIONS"
-The snoop command has one optional flag, the network interface to listen on\.
+The snoop command has one optional flag \- the network interface to listen on\.
 .
 .IP "\(bu" 4
 \fB\-i\fR, \fB\-\-iface=arg\fR: Network Interface (default: en0)
 .
 .IP "" 0
-.
-.P
-Wait for the network to quiet down, before pressing the button, since other devices may respond with ARP packets of their own when you press\. Take care to choose the MAC address from the ARP packet that occurs only once from a single MAC address\.
 .
 .P
 The \fBmonitor\fR command accepts the following flags, both a mac address and api token are required\.

--- a/man/lifx_dash.1.html
+++ b/man/lifx_dash.1.html
@@ -106,23 +106,23 @@ selector, or choose to daemonize the <code>monitor</code> process.</p>
 will also need a wifi network and root access to sniff packets on your network
 adaptor.</p>
 
-<p>Follow Amazon's Dash button setup steps, but <strong>stop</strong> before choosing any
-particular product to purchase. You aill also need a free LIFX API token from
-here: <a href="https://cloud.lifx.com/settings" data-bare-link="true">https://cloud.lifx.com/settings</a></p>
+<p>Follow Amazon's Dash button setup steps, but <strong>stop</strong> before choosing a product
+to purchase. Pressing the button should pulse white while connecting to wi-fi,
+then flash orange. If necessary, you can <a href="https://www.amazon.com/gp/help/customer/display.html?nodeId=201746400">factory
+reset</a>
+your button and start the setup from scratch.</p>
+
+<p>You will also need a free LIFX API token from here:
+<a href="https://cloud.lifx.com/settings" data-bare-link="true">https://cloud.lifx.com/settings</a></p>
 
 <h2 id="OPTIONS">OPTIONS</h2>
 
-<p>The snoop command has one optional flag, the network interface to listen on.</p>
+<p>The snoop command has one optional flag - the network interface to listen on.</p>
 
 <ul>
 <li><code>-i</code>, <code>--iface=arg</code>: Network Interface (default: en0)</li>
 </ul>
 
-
-<p>Wait for the network to quiet down, before pressing the button, since other
-devices may respond with ARP packets of their own when you press. Take care to
-choose the MAC address from the ARP packet that occurs only once from a single
-MAC address.</p>
 
 <p>The <code>monitor</code> command accepts the following flags, both a mac address and api
 token are required.</p>
@@ -208,7 +208,7 @@ by any arguments passed on the command line.</p>
 
   <ol class='man-decor man-foot man foot'>
     <li class='tl'></li>
-    <li class='tc'>June 2016</li>
+    <li class='tc'>June 2017</li>
     <li class='tr'>lifx_dash(1)</li>
   </ol>
 

--- a/man/lifx_dash.1.ronn
+++ b/man/lifx_dash.1.ronn
@@ -29,20 +29,20 @@ A `config` command also exists, allowing you to set default options for
 will also need a wifi network and root access to sniff packets on your network
 adaptor.
 
-Follow Amazon's Dash button setup steps, but **stop** before choosing any
-particular product to purchase. You aill also need a free LIFX API token from
-here: [https://cloud.lifx.com/settings](https://cloud.lifx.com/settings)
+Follow Amazon's Dash button setup steps, but **stop** before choosing a product
+to purchase. Pressing the button should pulse white while connecting to wi-fi,
+then flash orange. If necessary, you can [factory
+reset](https://www.amazon.com/gp/help/customer/display.html?nodeId=201746400)
+your button and start the setup from scratch.
+
+You will also need a free LIFX API token from here:
+[https://cloud.lifx.com/settings](https://cloud.lifx.com/settings)
 
 ## OPTIONS
 
-The snoop command has one optional flag, the network interface to listen on.
+The snoop command has one optional flag - the network interface to listen on.
 
 * `-i`, `--iface=arg`: Network Interface (default: en0)
-
-Wait for the network to quiet down, before pressing the button, since other
-devices may respond with ARP packets of their own when you press. Take care to
-choose the MAC address from the ARP packet that occurs only once from a single
-MAC address.
 
 The `monitor` command accepts the following flags, both a mac address and api
 token are required.


### PR DESCRIPTION
Change the capture filter to search for packets from both new and old dash buttons.

- older dash buttons issue an ARP packet from 0.0.0.0
- newer buttons broadcast a DHCP request from 0.0.0.0
- use the following bfp in WireShark to snoop for raw packets

    `(arp or (udp.srcport == 68 and udp.dstport == 67)) and ip.src == 0.0.0.0`

For more details see this related [issue](https://github.com/ide/dash-button/issues/36) on an npm module.
